### PR TITLE
set default admin theme to Seven

### DIFF
--- a/profiles/mediamosa_sb_kickstart/mediamosa_sb_kickstart.install
+++ b/profiles/mediamosa_sb_kickstart/mediamosa_sb_kickstart.install
@@ -68,7 +68,7 @@ function mediamosa_sb_kickstart_install() {
   theme_disable(array('bartik'));
 
   $default_theme = 'mediamosa_sb_theme';
-  $admin_theme = 'garland';
+  $admin_theme = 'seven';
   variable_set('theme_default', $default_theme);
   variable_set('admin_theme', $admin_theme);
   variable_set('node_admin_theme', 1);


### PR DESCRIPTION
Seven provides a clearer and better structured admin theme, Garland is a front-end theme. Just like Drupal 7, I propose that the Sitebuilder should have the Seven theme as default admin theme.
