### PR TITLE
Support for asset-published field.

### DIFF
--- a/sites/all/modules/custom/mediamosa_sb/mediamosa_sb.asset.forms.class.inc
+++ b/sites/all/modules/custom/mediamosa_sb/mediamosa_sb.asset.forms.class.inc
@@ -548,6 +548,20 @@ class mediamosa_sb_asset_forms {
       '#default_value' => self::default_value($values, 'is_downloadable', TRUE),
     );
 
+    $form['published'] = array(
+      '#type' => 'fieldset',
+      '#title' => t('Published'),
+      '#collapsible' => FALSE,
+      '#collapsed' => TRUE,
+    );
+    $form['published']['is_published'] = array(
+      '#type' => 'checkbox',
+      '#title' => t('Published'),
+      '#description' => t('Only published media is visible for others.'),
+      '#required' => FALSE,
+      '#default_value' => self::default_value($values, 'published', FALSE),
+    );
+
     return $form;
   }
 

--- a/sites/all/modules/custom/mediamosa_sb/mediamosa_sb.asset.inc
+++ b/sites/all/modules/custom/mediamosa_sb/mediamosa_sb.asset.inc
@@ -560,6 +560,12 @@ function mediamosa_sb_asset_edit_access_form($form, $form_state, $asset_id) {
     $values['license'] = (string) $asset->xml->items->item->qualified_dublin_core->license;
   }
 
+  // Published?
+  $values['published'] = '';
+  if (isset($asset->xml->items->item->asset->published)) {
+    $values['published'] = (string) $asset->xml->items->item->asset->published == 'TRUE' ? TRUE : FALSE;
+  }
+
   // Get the form.
   $form = mediamosa_sb_asset_forms::access_form($values);
 
@@ -600,7 +606,6 @@ function mediamosa_sb_asset_edit_access_form_submit($form, $form_state) {
       mediamosa_sb::submit_access($form_state['input'], $asset_id);
       break;
   }
-
   // Redirect.
   drupal_goto(mediamosa_sb::get_asset_detail_url($asset_id));
 }

--- a/sites/all/modules/custom/mediamosa_sb/mediamosa_sb.class.inc
+++ b/sites/all/modules/custom/mediamosa_sb/mediamosa_sb.class.inc
@@ -599,26 +599,35 @@ class mediamosa_sb {
   /**
    * Set access on mediafile.
    *
-   * @param $values
+   * @param array $values
    *   The submited values.
-   * @param $asset_id
+   * @param string $asset_id
    *   The asset ID.
-   *
-   * @return
    */
   static protected function submit_access_visibility($values, $asset_id) {
 
+    $options = array();
+    $app_options = array();
+    if (user_access(mediamosa_sb::MEDIAMOSA_SB_PERMISSION_EDIT_ASSETS)) {
+      $app_options = array('is_app_admin' => 'TRUE');
+    }
+
     // Save state isprivate to asset.
-    $options = array(
-      'isprivate' => (isset($values['is_visible']) && !empty($values['is_visible']) ? FALSE : TRUE),
-    );
-    MediaMosaSbConnectorWrapper::update_asset($asset_id, $options);
+    $options['isprivate'] = (isset($values['is_visible']) && !empty($values['is_visible']) ? FALSE : TRUE);
+    MediaMosaSbConnectorWrapper::update_asset($asset_id, array_merge($options, $app_options));
+
+    if ($values['is_published'] == 1) {
+      MediaMosaSbConnectorWrapper::asset_publish($asset_id, $app_options);
+    }
+    else {
+      MediaMosaSbConnectorWrapper::asset_unpublish($asset_id, $app_options);
+    }
 
     $options = array(
       'license' => $values['license'],
       'action' => 'update',
     );
-    MediaMosaSbConnectorWrapper::update_metadata($asset_id, $options);
+    MediaMosaSbConnectorWrapper::update_metadata($asset_id, array_merge($options, $app_options));
   }
 
   /**

--- a/sites/all/modules/custom/mediamosa_sb/mediamosa_sb.connector.wrapper.class.inc
+++ b/sites/all/modules/custom/mediamosa_sb/mediamosa_sb.connector.wrapper.class.inc
@@ -413,4 +413,51 @@ class MediaMosaSbConnectorWrapper extends MediaMosaCkConnectorWrapper {
     );
     return parent::update_asset($asset_id, $options);
   }
+
+  /**
+   * Publish an asset.
+   *
+   * @param array $options
+   *   The options for the asset.
+   *
+   * @return array
+   *   returns rest call output.
+   */
+  static public function asset_publish($asset_id, array $options = array()) {
+    // Need edit right.
+    if (mediamosa_sb::access_asset_edit($asset_id)) {
+      $options += array('user_id' => mediamosa_sb::get_owner_asset($asset_id));
+    }
+    try {
+      return mediamosa_ck::request_post_fatal('asset/' . rawurlencode($asset_id) . '/publish', array('data' => $options));
+    }
+    catch (Exception $e) {
+      mediamosa_ck::watchdog_error('Unable to update asset; !message.', array('!message' => $e->getMessage()));
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Publish an asset.
+   *
+   * @param array $options
+   *   The options for the asset.
+   *
+   * @return array
+   *   returns rest call output.
+   */
+  static public function asset_unpublish($asset_id, array $options = array()) {
+    // Need edit right.
+    if (mediamosa_sb::access_asset_edit($asset_id)) {
+      $options += array('user_id' => mediamosa_sb::get_owner_asset($asset_id));
+    }
+    try {
+      return mediamosa_ck::request_post_fatal('asset/' . rawurlencode($asset_id) . '/unpublish', array('data' => $options));
+    }
+    catch (Exception $e) {
+      mediamosa_ck::watchdog_error('Unable to update asset; !message.', array('!message' => $e->getMessage()));
+    }
+    return FALSE;
+  }
 }

--- a/sites/all/modules/custom/mediamosa_sb_feature/mediamosa_sb_feature.views_default.inc
+++ b/sites/all/modules/custom/mediamosa_sb_feature/mediamosa_sb_feature.views_default.inc
@@ -1363,6 +1363,11 @@ Consider loosening your query with OR. bike OR shed will often show more results
   $handler->display->display_options['filters']['owner_id']['table'] = 'mediamosa_asset_search';
   $handler->display->display_options['filters']['owner_id']['field'] = 'owner_id';
   $handler->display->display_options['filters']['owner_id']['value'] = '[user:mail]';
+  /* Filter criterion: MediaMosa: Published */
+  $handler->display->display_options['filters']['published']['id'] = 'published';
+  $handler->display->display_options['filters']['published']['table'] = 'mediamosa_asset_search';
+  $handler->display->display_options['filters']['published']['field'] = 'published';
+  $handler->display->display_options['filters']['published']['value'] = 'ALL';
 
   /* Display: Page */
   $handler = $view->new_display('page', 'Page', 'page');
@@ -1419,6 +1424,12 @@ Consider loosening your query with OR. bike OR shed will often show more results
   $handler->display->display_options['fields']['mediafile_duration']['hide_empty'] = TRUE;
   $handler->display->display_options['fields']['mediafile_duration']['date_format'] = 'mediamosa_ck_mf_duration';
   $handler->display->display_options['fields']['mediafile_duration']['custom_date_format'] = 'H:i';
+  /* Field: MediaMosa: Published */
+  $handler->display->display_options['fields']['published']['id'] = 'published';
+  $handler->display->display_options['fields']['published']['table'] = 'mediamosa_asset_search';
+  $handler->display->display_options['fields']['published']['field'] = 'published';
+  $handler->display->display_options['fields']['published']['label'] = '';
+  $handler->display->display_options['fields']['published']['element_label_colon'] = FALSE;
   $handler->display->display_options['path'] = 'myassets';
   $export['mediamosa_my_assets'] = $view;
 

--- a/sites/all/themes/mediamosa_sb_theme/css/views.css
+++ b/sites/all/themes/mediamosa_sb_theme/css/views.css
@@ -109,6 +109,13 @@
   font-size: 12px;
 }
 
+#page_content .view .asset-information .views-field-published {
+  position: absolute;
+  right: 10px;
+  bottom: 24px;
+  font-size: 12px;
+}
+
 #page_content .view .asset-information .views-field-owner-id .field-content,
 #page_content .view .asset-information .views-field-videotimestamp span {
   color: #686868;

--- a/sites/all/themes/mediamosa_sb_theme/templates/views/views-view--mediamosa-my-assets.tpl.php
+++ b/sites/all/themes/mediamosa_sb_theme/templates/views/views-view--mediamosa-my-assets.tpl.php
@@ -33,10 +33,6 @@
   </ul>
 </div>
 
-<p class="add-collection">
-  <?php print l('<span>' . t('Add a new asset') . '</span>', 'asset/upload', array('html' => TRUE)); ?>
-</p>
-
 <div class="<?php print $classes; ?>">
   <?php print render($title_prefix); ?>
   <?php if ($title): ?>

--- a/sites/all/themes/mediamosa_sb_theme/templates/views/views-view-fields--mediamosa-my-assets.tpl.php
+++ b/sites/all/themes/mediamosa_sb_theme/templates/views/views-view-fields--mediamosa-my-assets.tpl.php
@@ -49,6 +49,13 @@
   <?php print $fields['title']->content; ?>
   <?php print $fields['title']->wrapper_suffix; ?>
 
+  <?php if (isset($fields['published'])): ?>
+    <?php print $fields['published']->wrapper_prefix; ?>
+    <?php if (strip_tags($fields['published']->content) == 'TRUE'): print t('Published'); endif; ?>
+    <?php if (strip_tags($fields['published']->content) == 'FALSE'): print t('Not published'); endif; ?>
+    <?php print $fields['published']->wrapper_suffix; ?>
+  <?php endif; ?>
+
   <?php print $fields['videotimestamp']->wrapper_prefix; ?>
   <?php print $fields['videotimestamp']->content; ?>
   <?php print $fields['videotimestamp']->wrapper_suffix; ?>


### PR DESCRIPTION
The backend supports a published field, this patch builds support for it in the frontend. The access tab has a published field, to toggle status

Unpublished assets are only visible for the user and the app-admin.